### PR TITLE
Create Serverless Aurora PostgreSQL Databases

### DIFF
--- a/terraform/database/environments/production/config/backend.tfvars
+++ b/terraform/database/environments/production/config/backend.tfvars
@@ -1,0 +1,5 @@
+bucket = "cac-terraform-state-19384"
+dynamodb_table = "aws-terraform-state-lock"
+key = "us-east-1/production/database.tfstate"
+region = "us-east-1"
+encrypt = "true"

--- a/terraform/database/environments/production/config/terraform.tfvars
+++ b/terraform/database/environments/production/config/terraform.tfvars
@@ -1,0 +1,3 @@
+environment = "production"
+namespace = "cac"
+region = "us-east-1"

--- a/terraform/database/environments/staging/config/backend.tfvars
+++ b/terraform/database/environments/staging/config/backend.tfvars
@@ -1,0 +1,5 @@
+bucket = "cac-terraform-state-19384"
+dynamodb_table = "aws-terraform-state-lock"
+key = "us-east-1/staging/database.tfstate"
+region = "us-east-1"
+encrypt = "true"

--- a/terraform/database/environments/staging/config/terraform.tfvars
+++ b/terraform/database/environments/staging/config/terraform.tfvars
@@ -1,0 +1,6 @@
+environment = "staging"
+namespace = "cac"
+region = "us-east-1"
+cidr_block = "10.0.0.0/16"
+private_subnets = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
+public_subnets = ["10.0.2.0/24", "10.0.4.0/24", "10.0.6.0/24"]

--- a/terraform/database/environments/staging/config/terraform.tfvars
+++ b/terraform/database/environments/staging/config/terraform.tfvars
@@ -1,6 +1,3 @@
 environment = "staging"
 namespace = "cac"
 region = "us-east-1"
-cidr_block = "10.0.0.0/16"
-private_subnets = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
-public_subnets = ["10.0.2.0/24", "10.0.4.0/24", "10.0.6.0/24"]

--- a/terraform/database/module/backend.tf
+++ b/terraform/database/module/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/terraform/database/module/data.tf
+++ b/terraform/database/module/data.tf
@@ -1,0 +1,12 @@
+data "aws_vpc" "current" {
+  tags = {
+    Environment = var.environment
+  }
+}
+
+data "aws_subnet_ids" "private_subnets" {
+  vpc_id = data.aws_vpc.current.id
+  tags = {
+    Tier = "private"
+  }
+}

--- a/terraform/database/module/kms.tf
+++ b/terraform/database/module/kms.tf
@@ -1,0 +1,4 @@
+resource "aws_kms_key" "database" {
+  description             = "Database KMS key"
+  deletion_window_in_days = 7
+}

--- a/terraform/database/module/outputs.tf
+++ b/terraform/database/module/outputs.tf
@@ -1,0 +1,9 @@
+output "vpc_id" {
+  description = "The current VPC for this environment"
+  value       = data.aws_vpc.current.id
+}
+
+output "private_subnets" {
+  description = "The current private subnets for this environment"
+  value       = data.aws_subnet_ids.private_subnets.ids
+}

--- a/terraform/database/module/provider.tf
+++ b/terraform/database/module/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/terraform/database/module/rds.tf
+++ b/terraform/database/module/rds.tf
@@ -1,0 +1,40 @@
+module "label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.4.0"
+  namespace  = var.namespace
+  stage      = var.environment
+}
+
+module "aurora" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "~> 2.0"
+
+  name                  = module.label.id
+  engine                = "aurora-postgresql"
+  engine_version        = "10.7"
+  engine_mode           = "serverless"
+  replica_scale_enabled = false
+  replica_count         = 0
+  kms_key_id            = aws_kms_key.database.arn
+
+  backtrack_window = 10 # ignored in serverless
+
+  subnets                         = data.aws_subnet_ids.private_subnets.ids
+  vpc_id                          = data.aws_vpc.current.id
+  monitoring_interval             = 60
+  instance_type                   = "db.r4.large"
+  apply_immediately               = true
+  skip_final_snapshot             = true
+  storage_encrypted               = true
+
+  scaling_configuration = {
+    auto_pause               = true
+    min_capacity             = 2
+    max_capacity             = 384
+    seconds_until_auto_pause = 300
+    timeout_action           = "ForceApplyCapacityChange"
+  }
+
+  tags = {
+    Environment = var.environment
+  }
+}

--- a/terraform/database/module/variables.tf
+++ b/terraform/database/module/variables.tf
@@ -1,0 +1,12 @@
+variable "region" {
+  description = "aws region"
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment to deploy into"
+}
+
+variable "namespace" {
+  description = "Organization name or abbreviation"
+}

--- a/terraform/database/module/versions.tf
+++ b/terraform/database/module/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.24"
+}

--- a/terraform/vpc/module/vpc.tf
+++ b/terraform/vpc/module/vpc.tf
@@ -31,4 +31,12 @@ module "vpc" {
   tags = {
     Environment = var.environment
   }
+
+  public_subnet_tags = {
+    Tier = "public"
+  }
+
+  private_subnet_tags = {
+    Tier = "private"
+  }
 }


### PR DESCRIPTION
- Create serverless aurora (Postgres 10.7) databases for both staging and production
- Add tags to existing subnets to allow for easier filtering (tiers - private & public)